### PR TITLE
feat: implement a generic parser

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+compare.sh linguist-vendored=false

--- a/compare.sh
+++ b/compare.sh
@@ -9,6 +9,9 @@ fi
 args=("$@")
 search_term=$(printf "%s " "${args[@]}");
 search_term=${search_term%?};
+if [ -z "$search_term" ]; then
+    search_term="test";
+fi
 search_term_url=${search_term// /%20};
 
 # parameters

--- a/compare.sh
+++ b/compare.sh
@@ -16,8 +16,8 @@ search_term_url=${search_term// /%20};
 
 # parameters
 user_agent='MyAgent';
-warmup_count=10;
-min_runs=50;
+warmup_count=5;
+min_runs=10;
 
 # run hyperfine compare
 cargo build --release || exit;

--- a/compare.sh
+++ b/compare.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# if hyperfine command is not installed exit
+if ! command -v hyperfine &> /dev/null; then
+    echo "hyperfine command could not be found";
+    exit;
+fi
+
+args=("$@")
+search_term=$(printf "%s " "${args[@]}");
+search_term=${search_term%?};
+search_term_url=${search_term// /%20};
+
+# parameters
+user_agent='MyAgent';
+warmup_count=10;
+min_runs=50;
+
+# run hyperfine compare
+cargo build --release || exit;
+rustureng_command="./target/release/rustureng $search_term";
+curl_command="curl -s -o /dev/null 'https://tureng.com/en/turkish-english/$search_term_url' -H 'User-Agent: $user_agent'";
+hyperfine "$curl_command" "$rustureng_command" --warmup $warmup_count --min-runs $min_runs
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::{env, io::Write};
 
 const WORD: &str = "test";
 const WRITE_TO_FILE: bool = false;
-const QUIET: bool = true;
+const QUIET: bool = false;
 
 #[tokio::main]
 async fn main() -> Result<(), RetrieverError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,12 @@ async fn main() -> Result<(), RetrieverError> {
     }
 
     let translation_result = parse(&content).await;
-    println!("{:#?}", translation_result.len());
+    let results_of_first_table = translation_result[0]
+        .iter()
+        .map(|x| x.split_whitespace().collect::<Vec<_>>().join(" "))
+        .collect::<Vec<_>>();
+
+    println!("{:#?}", results_of_first_table);
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,9 +36,10 @@ async fn parse(content: &str) -> Vec<Vec<String>> {
     let table_selector = Selector::parse("table").unwrap();
     let tr_selector = Selector::parse("tr").unwrap();
     let td_with_a_selector = Selector::parse("td > a").unwrap();
+    let h1_selector = Selector::parse("h1").unwrap();
 
-    let tables = document.select(&table_selector);
-    tables
+    let translation_result = document
+        .select(&table_selector)
         .map(|table| {
             table
                 .select(&tr_selector)
@@ -46,7 +47,26 @@ async fn parse(content: &str) -> Vec<Vec<String>> {
                 .map(|tr| tr.text().collect::<Vec<_>>().join(""))
                 .collect::<Vec<String>>()
         })
-        .collect::<Vec<_>>()
+        .collect::<Vec<_>>();
+
+    if translation_result.is_empty() {
+        let term_not_found_h1_exists = document.select(&h1_selector).any(|h1| {
+            "term not found" == h1.text().collect::<Vec<_>>().join("").trim().to_lowercase()
+        });
+
+        match term_not_found_h1_exists {
+            true => {
+                println!("Term not found");
+                vec![]
+            }
+            _ => {
+                println!("Suggestions");
+                vec![]
+            }
+        }
+    } else {
+        translation_result
+    }
 }
 
 async fn save_string_to_file(file_name: &str, content: &str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,30 @@
-use rustureng::parser::{parse_html_content, TranslationResult};
 use rustureng::retriever::{self, RetrieverError};
+use scraper::{Html, Selector};
 // use rustureng::retriever_reqwest::{self as retriever, RetrieverError};
 use std::{env, io::Write};
 
 const WORD: &str = "test";
 const WRITE_TO_FILE: bool = false;
+
+#[allow(dead_code)]
+struct ValidTranslationEntry {
+    pub number: usize,
+    pub word: String,
+    pub translation: String,
+    pub part_of_speech: String,
+}
+
+#[allow(dead_code)]
+impl ValidTranslationEntry {
+    fn new(number: usize, word: String, translation: String, part_of_speech: String) -> Self {
+        Self {
+            number,
+            word,
+            translation,
+            part_of_speech,
+        }
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), RetrieverError> {
@@ -19,26 +39,41 @@ async fn main() -> Result<(), RetrieverError> {
         save_string_to_file("content.html", &content).await;
     }
 
-    let translation_result = parse_html_content(&content).await;
-    match translation_result {
-        TranslationResult::Valid(results) => {
-            for result in results.iter() {
-                let result_table = result
-                    .iter()
-                    .map(|x| x.split_whitespace().collect::<Vec<_>>().join(" "))
-                    .collect::<Vec<_>>();
-                println!("{:#?}\n", result_table);
-            }
-        }
-        TranslationResult::Suggestions(suggestions) => {
-            println!("Suggestions:");
-            for suggestion in suggestions.iter() {
-                println!("{}", suggestion);
-            }
-        }
-        TranslationResult::TermNotFound => println!("Term not found"),
-    }
+    parse_html_content(&content).await;
     Ok(())
+}
+
+async fn parse_html_content(content: &str) {
+    let document = Html::parse_document(content);
+    let table_selector = Selector::parse("table").unwrap();
+    let tr_selector = Selector::parse("tr").unwrap();
+    let td_selector = Selector::parse("td").unwrap();
+    let td_with_a_selector = Selector::parse("td > a").unwrap();
+
+    let translation_result = document
+        .select(&table_selector)
+        .map(|table| {
+            table
+                .select(&tr_selector)
+                .filter(|tr| tr.select(&td_with_a_selector).count() > 0)
+                // .map(|tr| tr.text().collect::<Vec<_>>().join(""))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    let a = translation_result[1][2]
+        .select(&td_selector)
+        .map(|td| {
+            if td.inner_html().contains("<i>") {
+                td.inner_html()
+            } else {
+                td.text().collect::<Vec<_>>().join("")
+            }
+        })
+        .map(|x| x.trim().to_string())
+        .filter(|td| !td.is_empty())
+        .collect::<Vec<_>>();
+    println!("{:#?}", a);
 }
 
 async fn save_string_to_file(file_name: &str, content: &str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,30 +1,10 @@
+use rustureng::parser::{parse_html_content, TranslationResult};
 use rustureng::retriever::{self, RetrieverError};
-use scraper::{Html, Selector};
 // use rustureng::retriever_reqwest::{self as retriever, RetrieverError};
 use std::{env, io::Write};
 
 const WORD: &str = "test";
 const WRITE_TO_FILE: bool = false;
-
-#[allow(dead_code)]
-struct ValidTranslationEntry {
-    pub number: usize,
-    pub word: String,
-    pub translation: String,
-    pub part_of_speech: String,
-}
-
-#[allow(dead_code)]
-impl ValidTranslationEntry {
-    fn new(number: usize, word: String, translation: String, part_of_speech: String) -> Self {
-        Self {
-            number,
-            word,
-            translation,
-            part_of_speech,
-        }
-    }
-}
 
 #[tokio::main]
 async fn main() -> Result<(), RetrieverError> {
@@ -39,41 +19,19 @@ async fn main() -> Result<(), RetrieverError> {
         save_string_to_file("content.html", &content).await;
     }
 
-    parse_html_content(&content).await;
+    let translation_result = parse_html_content(&content).await;
+    match translation_result {
+        TranslationResult::Valid(results) => {
+            println!("{:#?}", results);
+        }
+        TranslationResult::Suggestions(suggestions) => {
+            println!("{:#?}", suggestions);
+        }
+        TranslationResult::TermNotFound => {
+            println!("Term not found");
+        }
+    }
     Ok(())
-}
-
-async fn parse_html_content(content: &str) {
-    let document = Html::parse_document(content);
-    let table_selector = Selector::parse("table").unwrap();
-    let tr_selector = Selector::parse("tr").unwrap();
-    let td_selector = Selector::parse("td").unwrap();
-    let td_with_a_selector = Selector::parse("td > a").unwrap();
-
-    let translation_result = document
-        .select(&table_selector)
-        .map(|table| {
-            table
-                .select(&tr_selector)
-                .filter(|tr| tr.select(&td_with_a_selector).count() > 0)
-                // .map(|tr| tr.text().collect::<Vec<_>>().join(""))
-                .collect::<Vec<_>>()
-        })
-        .collect::<Vec<_>>();
-
-    let a = translation_result[1][2]
-        .select(&td_selector)
-        .map(|td| {
-            if td.inner_html().contains("<i>") {
-                td.inner_html()
-            } else {
-                td.text().collect::<Vec<_>>().join("")
-            }
-        })
-        .map(|x| x.trim().to_string())
-        .filter(|td| !td.is_empty())
-        .collect::<Vec<_>>();
-    println!("{:#?}", a);
 }
 
 async fn save_string_to_file(file_name: &str, content: &str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,12 +21,13 @@ async fn main() -> Result<(), RetrieverError> {
     }
 
     let translation_result = parse(&content).await;
-    let results_of_first_table = translation_result[0]
-        .iter()
-        .map(|x| x.split_whitespace().collect::<Vec<_>>().join(" "))
-        .collect::<Vec<_>>();
-
-    println!("{:#?}", results_of_first_table);
+    for res in translation_result.iter() {
+        let results_of_first_table = res
+            .iter()
+            .map(|x| x.split_whitespace().collect::<Vec<_>>().join(" "))
+            .collect::<Vec<_>>();
+        println!("{:#?}\n", results_of_first_table);
+    }
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use std::{env, io::Write};
 
 const WORD: &str = "test";
 const WRITE_TO_FILE: bool = false;
+const QUIET: bool = true;
 
 #[tokio::main]
 async fn main() -> Result<(), RetrieverError> {
@@ -20,19 +21,21 @@ async fn main() -> Result<(), RetrieverError> {
     }
 
     let translation_result = parse_html_content(&content).await;
-    match translation_result {
-        TranslationResult::Valid(results) => {
-            for result in results {
-                for entry in result {
-                    println!("{}", entry);
+    if !QUIET {
+        match translation_result {
+            TranslationResult::Valid(results) => {
+                for result in results {
+                    for entry in result {
+                        println!("{}", entry);
+                    }
                 }
             }
-        }
-        TranslationResult::Suggestions(suggestions) => {
-            println!("{:#?}", suggestions);
-        }
-        TranslationResult::TermNotFound => {
-            println!("Term not found");
+            TranslationResult::Suggestions(suggestions) => {
+                println!("{:#?}", suggestions);
+            }
+            TranslationResult::TermNotFound => {
+                println!("Term not found");
+            }
         }
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
-use rustureng::parser::parse_html_content;
+use scraper::{Html, Selector};
+// use rustureng::parser::parse_html_content;
 use rustureng::retriever::{self, RetrieverError};
 // use rustureng::retriever_reqwest::{self as retriever, RetrieverError};
 use std::{env, io::Write};
 
-const WORD: &str = "telefon";
+const WORD: &str = "test";
 const WRITE_TO_FILE: bool = false;
 
 #[tokio::main]
@@ -18,9 +19,28 @@ async fn main() -> Result<(), RetrieverError> {
     if WRITE_TO_FILE {
         save_string_to_file("content.html", &content).await;
     }
-    let translation_result = parse_html_content(&content).await;
-    println!("{translation_result:#?}");
+
+    let translation_result = parse(&content).await;
+    println!("{:#?}", translation_result.len());
     Ok(())
+}
+
+async fn parse(content: &str) -> Vec<Vec<String>> {
+    let document = Html::parse_document(content);
+    let table_selector = Selector::parse("table").unwrap();
+    let tr_selector = Selector::parse("tr").unwrap();
+    let td_with_a_selector = Selector::parse("td > a").unwrap();
+
+    let tables = document.select(&table_selector);
+    tables
+        .map(|table| {
+            table
+                .select(&tr_selector)
+                .filter(|tr| tr.select(&td_with_a_selector).count() > 0)
+                .map(|tr| tr.text().collect::<Vec<_>>().join(""))
+                .collect::<Vec<String>>()
+        })
+        .collect::<Vec<_>>()
 }
 
 async fn save_string_to_file(file_name: &str, content: &str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,11 @@ async fn main() -> Result<(), RetrieverError> {
     let translation_result = parse_html_content(&content).await;
     match translation_result {
         TranslationResult::Valid(results) => {
-            println!("{:#?}", results);
+            for result in results {
+                for entry in result {
+                    println!("{}", entry);
+                }
+            }
         }
         TranslationResult::Suggestions(suggestions) => {
             println!("{:#?}", suggestions);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -50,7 +50,7 @@ impl ValidTranslationEntry {
 
 pub async fn parse_html_content(content: &str) -> TranslationResult {
     let document = Html::parse_document(content);
-    let translation_result = get_results(&document).await;
+    let translation_result = get_results(&document);
 
     if translation_result.is_empty() {
         let h1_selector = Selector::parse("h1").unwrap();
@@ -60,14 +60,14 @@ pub async fn parse_html_content(content: &str) -> TranslationResult {
 
         match term_not_found_h1_exists {
             true => TranslationResult::TermNotFound,
-            _ => TranslationResult::Suggestions(get_suggestions(&document).await),
+            _ => TranslationResult::Suggestions(get_suggestions(&document)),
         }
     } else {
         TranslationResult::Valid(translation_result)
     }
 }
 
-async fn get_results(document: &Html) -> Vec<Vec<ValidTranslationEntry>> {
+fn get_results(document: &Html) -> Vec<Vec<ValidTranslationEntry>> {
     let table_selector = Selector::parse("table").unwrap();
     let tr_selector = Selector::parse("tr").unwrap();
     let td_selector = Selector::parse("td").unwrap();
@@ -106,7 +106,7 @@ async fn get_results(document: &Html) -> Vec<Vec<ValidTranslationEntry>> {
         .collect::<Vec<_>>()
 }
 
-async fn get_suggestions(document: &Html) -> Vec<String> {
+fn get_suggestions(document: &Html) -> Vec<String> {
     let selector = Selector::parse("ul.suggestion-list > li > a").unwrap();
     document
         .select(&selector)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -155,3 +155,44 @@ fn get_result_from_td(
         (td.text().collect::<Vec<_>>().join(""), None)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    const SAMPLE_TABLE_STR: &str = r#"
+        <h1>test</h1>
+        <table class="table table-hover table-striped searchResultsTable" id="englishResultsTable">
+            <tbody>
+                <tr>
+                    <td class="rc0 hidden-xs">1</td>
+                    <td class="hidden-xs">Common Usage</td>
+                    <td class="tr ts" lang="tr"><a href="/en/turkish-english/kedi">kedi</a></td>
+                    <td class="en tm" lang="en"><a href="/en/turkish-english/cat">cat</a><i>n. </i></td>
+                    <td class="rc4 hidden-xs"><span class="glyphicon glyphicon-option-horizontal"></span></td>
+                </tr>
+            </tbody>
+        </table>
+        "#;
+
+    #[test]
+    fn test_get_result_from_tr() {
+        let table_tr_selector = Selector::parse("table").unwrap();
+        let tr_selector = Selector::parse("tr").unwrap();
+        let td_selector = Selector::parse("td").unwrap();
+        let i_selector = Selector::parse("i").unwrap();
+        let a_selector = Selector::parse("a").unwrap();
+
+        let table_html = Html::parse_document(SAMPLE_TABLE_STR);
+        let sample_tr = table_html
+            .select(&table_tr_selector)
+            .map(|table| table.select(&tr_selector).next().unwrap())
+            .next()
+            .unwrap();
+
+        let entry = get_result_from_tr(&sample_tr, &td_selector, &i_selector, &a_selector);
+        assert_eq!(entry.index, 1);
+        assert_eq!(entry.from, "kedi".to_string());
+        assert_eq!(entry.to, "cat".to_string());
+        assert_eq!(entry.parts_of_speech, Some("n.".to_string()));
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,43 +2,45 @@ use scraper::{Html, Selector};
 
 #[derive(Debug)]
 pub enum TranslationResult {
-    Valid(Vec<String>),
+    Valid(Vec<Vec<String>>),
     Suggestions(Vec<String>),
     TermNotFound,
 }
 
 pub async fn parse_html_content(content: &str) -> TranslationResult {
     let document = Html::parse_document(content);
-    let table_selector = Selector::parse("table").unwrap();
-    let h1_selector = Selector::parse("h1").unwrap();
+    let translation_result = get_results(&document).await;
 
-    let tables = document.select(&table_selector);
+    if translation_result.is_empty() {
+        let h1_selector = Selector::parse("h1").unwrap();
+        let term_not_found_h1_exists = document.select(&h1_selector).any(|h1| {
+            "term not found" == h1.text().collect::<Vec<_>>().join("").trim().to_lowercase()
+        });
 
-    match tables.count() {
-        0 => {
-            let term_not_found_h1_exists = document.select(&h1_selector).any(|h1| {
-                "term not found" == h1.text().collect::<Vec<_>>().join("").trim().to_lowercase()
-            });
-
-            match term_not_found_h1_exists {
-                true => TranslationResult::TermNotFound,
-                _ => TranslationResult::Suggestions(get_suggestions(&document).await),
-            }
+        match term_not_found_h1_exists {
+            true => TranslationResult::TermNotFound,
+            _ => TranslationResult::Suggestions(get_suggestions(&document).await),
         }
-        _ => TranslationResult::Valid(get_results(&document).await),
+    } else {
+        TranslationResult::Valid(translation_result)
     }
 }
 
-async fn get_results(document: &Html) -> Vec<String> {
-    let selector = Selector::parse(r#"table > tbody > tr > td > a"#).unwrap();
-    let entries = document.select(&selector);
-    entries
-        .into_iter()
-        .enumerate()
-        .take(20)
-        .filter(|(i, _)| i % 2 == 1) // get every other entry
-        .map(|(_, entry)| entry.text().collect::<Vec<_>>().join("")) // get the text
-        .collect()
+async fn get_results(document: &Html) -> Vec<Vec<String>> {
+    let table_selector = Selector::parse("table").unwrap();
+    let tr_selector = Selector::parse("tr").unwrap();
+    let td_with_a_selector = Selector::parse("td > a").unwrap();
+
+    document
+        .select(&table_selector)
+        .map(|table| {
+            table
+                .select(&tr_selector)
+                .filter(|tr| tr.select(&td_with_a_selector).count() > 0)
+                .map(|tr| tr.text().collect::<Vec<_>>().join(""))
+                .collect::<Vec<String>>()
+        })
+        .collect::<Vec<_>>()
 }
 
 async fn get_suggestions(document: &Html) -> Vec<String> {

--- a/src/retriever.rs
+++ b/src/retriever.rs
@@ -1,4 +1,4 @@
-use isahc::{http::StatusCode, prelude::*, Error as IsahcError, HttpClient};
+use isahc::{http::StatusCode, prelude::AsyncReadResponseExt, Error as IsahcError, HttpClient};
 use std::io::Error as IOError;
 use url::{ParseError, Url};
 


### PR DESCRIPTION
Implement a generic parser which addresses the short-comings defined
in issue #3. During the process of implementing the new parser,
unnecessary `async` calls are also pruned, and a shell-script is
provided to compare performance between the crate and basic `curl`
command.

- feat: initialize better parser
- feat: enhance display output
- fix: update output display to show all tables
- feat: add basic translation result check
- feat: replace default parser
- feat: initialize detailed result parsing
- feat: update parser to extract `pos`
- feat: convert valid translation entry to `struct`
- fix(async): remove unnecessary `async` functions
- refactor: export `tr` result generation
- feat: add `quiet` option to suppress `stdout`
- perf(isahc): remove unnecessary `prelude` import
- test: add `curl` performance comparison script
- fix: default `quiet` behavior to `false`
- fix: add default term to `compare.sh`
- fix: decrease compare script run numbers
- test(parser): add unit test to `tr` result parsing
